### PR TITLE
Exclude vendor directory from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ exclude:
   - build.bash
   - Gemfile
   - Gemfile.lock
+  - vendor
 
 #Build settings
 permalinks: pretty


### PR DESCRIPTION
Prevents Jekyll from crawling into bundled gem files and failing on template files with ERB date expressions.

https://claude.ai/code/session_01RYsMHT4Sp8BDZLYW9zdQKp