### PR TITLE
Add kramdown-parser-gfm dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 3.9"
+gem "kramdown-parser-gfm"
 gem "jekyll-feed"
 gem "jekyll-redirect-from"


### PR DESCRIPTION
Required by Jekyll 3.x with kramdown markdown processor.

https://claude.ai/code/session_01RYsMHT4Sp8BDZLYW9zdQKp