### PR TITLE
Install gems outside project directory to fix Jekyll cleaner stack ov…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Build Jekyll site
         run: bundle exec jekyll build


### PR DESCRIPTION
…erflow

bundler-cache: true installs gems to vendor/bundle inside the project. Jekyll 3.10's cleaner.rb#parent_dirs recurses infinitely through the deeply-nested gem paths, causing SystemStackError. Installing gems to the default system location keeps them out of the source tree.

https://claude.ai/code/session_01RYsMHT4Sp8BDZLYW9zdQKp