### PR TITLE
Fix Jekyll build: pin to 3.9.x, repair config/plugin issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Build Jekyll site
         run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.9"
+gem "jekyll", "~> 3.9.5"
 gem "kramdown-parser-gfm"
 gem "jekyll-feed"
 gem "jekyll-redirect-from"

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ exclude:
   - vendor
 
 #Build settings
-permalinks: pretty
+permalink: pretty
 markdown: kramdown
 
 plugins:

--- a/_plugins/alias_generator.rb
+++ b/_plugins/alias_generator.rb
@@ -39,7 +39,7 @@ module Jekyll
     end
 
     def process_posts
-      @site.posts.each do |post|
+      @site.posts.docs.each do |post|
         generate_aliases(post.url, post.data['alias'])
       end
     end


### PR DESCRIPTION
- Gemfile: pin jekyll to ~> 3.9.5 to exclude 3.10.0, which introduced a regression in cleaner.rb#parent_dirs that causes SystemStackError when processing static files added by alias_generator.rb

- _config.yml: fix 'permalinks' (plural, silently ignored) -> 'permalink' so pretty URLs are actually applied

- _plugins/alias_generator.rb: fix posts.each -> posts.docs.each to eliminate the deprecation warning from Jekyll 3.10's collection API

- deploy.yml: restore bundler-cache: true (safe now that Jekyll 3.9.x is pinned; removes the separate bundle install step)

https://claude.ai/code/session_01RYsMHT4Sp8BDZLYW9zdQKp