### PR TITLE
Update bio for current role at Aptible; fix remaining alias: front ma…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 name: "Lingnik : Taylor J. Meek"
 title: Taylor J. Meek
 email: taylor.meek@gmail.com
-description: "Taylor is a senior software engineering manager who used to write software, do things with machine learning and linguistics, and mess around with servers. He fancies the outdoors and is grateful that Portland, OR has so much of it. He currently works for Heroku, a Salesforce company, where he leads the Heroku Tools Team--a stellar group of Ruby and Go engineers who build internal tools and services that help our colleagues focus on what they do best. Although he enjoys talking about himself in the third person, he'd rather be talking to you face-to-face. Stupid pandemic."
+description: "Taylor is a staff software engineer at Aptible, where he builds Managed AI services for a HIPAA-compliant PaaS. He spent seven years leading engineering teams at CloudBolt, Heroku, and Salesforce before deciding he missed writing code more than he missed expense reports. He fancies the outdoors and is grateful that Portland, OR has so much of it. Although he enjoys talking about himself in the third person, he'd rather be talking to you face-to-face."
 icon: "/favicon.ico"
 baseurl: ""
 url: "http://lingnik.com"

--- a/about.md
+++ b/about.md
@@ -2,29 +2,36 @@
 layout: page
 title: About
 permalink: /about/
-alias: [/about.htm, /resume.htm, /resume/index.html, /profession/index.html, /profession/resume/index.html]
+redirect_from: [/about.htm, /resume.htm, /resume/index.html, /profession/index.html, /profession/resume/index.html]
 ---
 
 ![Taylor J. Meek : Lingnik](https://www.gravatar.com/avatar/87b4f3fdb782126274ee6157c36c9352?s=150)
 
 I believe in using technology, through the application of sound software
 engineering practices, to solve problems. *Software Engineer* puts too much
-emphasis on the tool that I use, and not the thing that I do. Those things I am
+emphasis on the tool that I use, and not the thing that I do. The things I am
 most passionate about mirror my work and education: stewardship for the
 environment and more effective human collaboration.
 
-At CloudBolt Software, I help enterprise teams leverage cloud computing
-resources and their existing servers faster and better by leading the product
-development team and contributing core code myself. I previously worked in the
-renewable energy space as a lead EMS-SCADA developer, facilitating the
-efficient delivery of wind and hydroelectric power.
+After twelve years as an engineer, I spent seven leading teams — at CloudBolt
+Software, then at Heroku and Salesforce, where I ran teams focused on Data,
+Internal Tools, and AI Platform infrastructure. In 2022, I [decided to stop
+being a manager](/2022/06/07/i-am-an-engineer-again-or-there-and-back-again/)
+and go back to writing code. I have no regrets, and a lot of useful scars.
+
+These days I'm a Staff Software Engineer at [Aptible](https://aptible.com),
+building Managed AI services on a HIPAA-compliant PaaS. If you're building AI
+products that need to handle protected health information without a compliance
+nightmare, that's where I live.
 
 The studies I took on at Portland State gave me a primer in Linguistics and
-deepened my fascination of using technology to help people communicate better.
+deepened my fascination with using technology to help people communicate better.
+I co-founded a machine learning and speech recognition startup, got a paper on
+AI ethics [published at PICMET](https://ieeexplore.ieee.org/document/7806752),
+and hold a cloud compliance patent. The through-line is figuring out how
+machines and humans can work better together.
 
-I sometimes teach Python and Django classes and alongside my (arborist) wife,
-my volunteer hat includes being a crew leader for Friends of Trees, where we
-help make our city a greener and greater place to live. We share a small home
-in inner southeast Portland where our family raises chickens and a duck for
-eggs and tends a garden for produce -- and love living in a diverse city with
-things to do.
+Alongside my (arborist) wife, my volunteer hat includes being a crew leader for
+Friends of Trees, where we help make our city a greener place to live. We share
+a small home in inner southeast Portland where our family raises chickens and
+tends a garden — and love living in a diverse city with things to do.

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-alias: [/projects.htm, /resume.htm, /journal.htm, /programs.htm, /contact.htm, /sources.htm, /calendar.htm, /comic.htm, /daily.htm, /interest.htm, /lists.php, /older.htm, /tasks.php, /welcome.html, /pirates/index.html, /projects/index.html, /journal/index.html, /software/index.html, /contact/index.html, /sources/index.html, /cotd/index.html, /projects/pirates/index.html]
+redirect_from: [/projects.htm, /resume.htm, /journal.htm, /programs.htm, /contact.htm, /sources.htm, /calendar.htm, /comic.htm, /daily.htm, /interest.htm, /lists.php, /older.htm, /tasks.php, /welcome.html, /pirates/index.html, /projects/index.html, /journal/index.html, /software/index.html, /contact/index.html, /sources/index.html, /cotd/index.html, /projects/pirates/index.html]
 ---
 
 <div class="home">


### PR DESCRIPTION
…tter

- _config.yml: update description to reflect staff SWE role at Aptible building Managed AI on HIPAA-compliant PaaS; retire Heroku-era copy

- about.md: full bio rewrite — keeps the opening values statement and Portland/personal details, adds the manager→engineer arc (linking to the 2022 blog post) and current Aptible role; also converts alias: to redirect_from: now that alias_generator.rb is gone

- index.html: convert alias: to redirect_from: (same reason)

https://claude.ai/code/session_01RYsMHT4Sp8BDZLYW9zdQKp